### PR TITLE
Fixing Ecto integration module loading

### DIFF
--- a/lib/beaker/integrations/ecto.ex
+++ b/lib/beaker/integrations/ecto.ex
@@ -1,19 +1,17 @@
-if Code.ensure_loaded?(Ecto.Repo) do
-  defmodule Beaker.Integrations.Ecto do
-    @moduledoc false
+defmodule Beaker.Integrations.Ecto do
+  @moduledoc false
 
-    defmacro __using__(_opts) do
-      quote do
-        def log(entry) do
-          if entry.query_time, do: Beaker.TimeSeries.sample("Ecto:QueryTime", entry.query_time / 1000)
-          if entry.queue_time, do: Beaker.TimeSeries.sample("Ecto:QueueTime", entry.queue_time / 1000)
-          Beaker.Counter.incr("Ecto:Queries")
+  defmacro __using__(_opts) do
+    quote do
+      def log(entry) do
+        if entry.query_time, do: Beaker.TimeSeries.sample("Ecto:QueryTime", entry.query_time / 1000)
+        if entry.queue_time, do: Beaker.TimeSeries.sample("Ecto:QueueTime", entry.queue_time / 1000)
+        Beaker.Counter.incr("Ecto:Queries")
 
-          super(entry)
-        end
-
-        defoverridable [log: 1]
+        super(entry)
       end
+
+      defoverridable [log: 1]
     end
   end
 end


### PR DESCRIPTION
Corresponding issue: https://github.com/hahuang65/beaker/issues/6

Allow `Beaker.Integrations.Ecto` module be compiled even if `Ecto.Repo` is not loaded yet.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hahuang65/beaker/7)

<!-- Reviewable:end -->
