### PR TITLE
Time as milliseconds for API and named object

### DIFF
--- a/API_doc.md
+++ b/API_doc.md
@@ -33,32 +33,29 @@ cache-control: max-age=0, private, must-revalidate
 {
   "time_series3": [
     {
-      "1453283760000000": {
-        "min": 30,
-        "max": 30,
-        "count": 1,
-        "average": 30.0
-      }
+      "time": 1453354560000,
+      "min": 30,
+      "max": 30,
+      "count": 1,
+      "average": 30.0
     }
   ],
   "time_series2": [
     {
-      "1453283760000000": {
-        "min": 20,
-        "max": 20,
-        "count": 1,
-        "average": 20.0
-      }
+      "time": 1453354560000,
+      "min": 20,
+      "max": 20,
+      "count": 1,
+      "average": 20.0
     }
   ],
   "time_series1": [
     {
-      "1453283760000000": {
-        "min": 10,
-        "max": 10,
-        "count": 1,
-        "average": 10.0
-      }
+      "time": 1453354560000,
+      "min": 10,
+      "max": 10,
+      "count": 1,
+      "average": 10.0
     }
   ]
 }
@@ -150,7 +147,7 @@ cache-control: max-age=0, private, must-revalidate
   "api_time_series": [
     {
       "value": 42,
-      "time": 1453283818600353
+      "time": 1453354575827
     }
   ]
 }

--- a/lib/beaker/formatters/aggregated.ex
+++ b/lib/beaker/formatters/aggregated.ex
@@ -26,6 +26,6 @@ defmodule Beaker.Formatters.Aggregate do
 
   def get_values({time, {avg, min,  max, count}}) do
     time_as_milliseconds = Beaker.Time.to_milliseconds(time)
-    Map.put(%{}, "#{time_as_milliseconds}", %{average: avg, min: min, max: max, count: count})
+    %{time: time_as_milliseconds, average: avg, min: min, max: max, count: count}
   end
 end

--- a/lib/beaker/formatters/aggregated.ex
+++ b/lib/beaker/formatters/aggregated.ex
@@ -25,6 +25,7 @@ defmodule Beaker.Formatters.Aggregate do
   end
 
   def get_values({time, {avg, min,  max, count}}) do
-    Map.put(%{}, "#{time}", %{average: avg, min: min, max: max, count: count})
+    time_as_milliseconds = Beaker.Time.to_milliseconds(time)
+    Map.put(%{}, "#{time_as_milliseconds}", %{average: avg, min: min, max: max, count: count})
   end
 end

--- a/lib/web/controllers/metrics_api_controller.ex
+++ b/lib/web/controllers/metrics_api_controller.ex
@@ -4,8 +4,8 @@ if Code.ensure_loaded?(Phoenix.Controller) do
 
     def counters(conn, _params) do
       counters = Beaker.Counter.all
-      |> Enum.map(fn {key, value} -> %{measurement: key, value: value} end)
-      
+      |> Enum.map(fn {key, value} -> %{name: key, value: value} end)
+
       conn
       |> json(counters)
     end

--- a/lib/web/controllers/metrics_api_controller.ex
+++ b/lib/web/controllers/metrics_api_controller.ex
@@ -4,6 +4,8 @@ if Code.ensure_loaded?(Phoenix.Controller) do
 
     def counters(conn, _params) do
       counters = Beaker.Counter.all
+      |> Enum.map(fn {key, value} -> %{measurement: key, value: value} end)
+      
       conn
       |> json(counters)
     end

--- a/lib/web/controllers/metrics_api_controller.ex
+++ b/lib/web/controllers/metrics_api_controller.ex
@@ -37,7 +37,8 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     end
 
     defp tuples_to_map({time, value}) do
-      %{time: time, value: value}
+      time_as_milliseconds = Beaker.Time.to_milliseconds(time)
+      %{time: time_as_milliseconds, value: value}
     end
 
   end

--- a/test/lib/beaker/formatters/aggregate_formatter_test.exs
+++ b/test/lib/beaker/formatters/aggregate_formatter_test.exs
@@ -32,11 +32,11 @@ defmodule Beaker.Formatters.AggregateTest do
 
     measurement = aggregation_series_1 |> hd
 
-    assert get_value(measurement) == %{average: 10.0, count: 1, max: 10, min: 10}
+    assert measurement.average == 10.0
+    assert measurement.count == 1
+    assert measurement.max == 10
+    assert measurement.min == 10
+    assert measurement.time != nil
   end
 
-  defp get_value(map) do
-    key = Map.keys(map) |> hd
-    Map.get(map, key)
-  end
 end

--- a/test/web/controllers/metrics_api_controller_test.exs
+++ b/test/web/controllers/metrics_api_controller_test.exs
@@ -30,7 +30,7 @@ defmodule Beaker.Controllers.MetricsApiControllerTest do
 
     decoded = Poison.decode!(response.resp_body)
 
-    assert decoded == %{"api" => 1}
+    assert decoded == [%{"measurement" => "api", "value" => 1}]
   end
 
   test "GET /api/gauges" do

--- a/test/web/controllers/metrics_api_controller_test.exs
+++ b/test/web/controllers/metrics_api_controller_test.exs
@@ -21,7 +21,7 @@ defmodule Beaker.Controllers.MetricsApiControllerTest do
   end
 
   test "GET /api/counters" do
-    Counter.set("api", 1)
+    Counter.set("api_counter", 1)
 
     response = get_response("/api/counters")
     |> doc
@@ -30,7 +30,7 @@ defmodule Beaker.Controllers.MetricsApiControllerTest do
 
     decoded = Poison.decode!(response.resp_body)
 
-    assert decoded == [%{"measurement" => "api", "value" => 1}]
+    assert decoded == [%{"name" => "api_counter", "value" => 1}]
   end
 
   test "GET /api/gauges" do


### PR DESCRIPTION
In order to provide more straightforward handling of dates in JS, this PR sends the timestamps as milliseconds.

In order to make it simpler to add lots of charts and deal with them programmatically on the frontend, I've added a `name` property to the sent maps.

Looking forward to feedback :)
