### PR TITLE
Ecto 2.0 changes

### DIFF
--- a/lib/beaker/integrations/ecto.ex
+++ b/lib/beaker/integrations/ecto.ex
@@ -3,15 +3,14 @@ defmodule Beaker.Integrations.Ecto do
 
   defmacro __using__(_opts) do
     quote do
-      def log(entry) do
+      defoverridable [__log__: 1]
+      def __log__(entry) do
         if entry.query_time, do: Beaker.TimeSeries.sample("Ecto:QueryTime", entry.query_time / 1000)
         if entry.queue_time, do: Beaker.TimeSeries.sample("Ecto:QueueTime", entry.queue_time / 1000)
         Beaker.Counter.incr("Ecto:Queries")
 
         super(entry)
       end
-
-      defoverridable [log: 1]
     end
   end
 end


### PR DESCRIPTION
`log/1` was renamed to `__log__/1`.

It seems the intent was to have users add to their config all the desired
logger mfa tuples. That would require more effort on the users of Beaker
and be a backwards incompatible change. Don't mind changing to that, but I
figured it can be done easily the way I've done here and it should still
work just fine without any changes to user code.

We can change it to the ecto 2.0 way if desired...
