### PR TITLE
Remove runtime calls to Mix.env/0

### DIFF
--- a/lib/beaker/time_series/aggregator.ex
+++ b/lib/beaker/time_series/aggregator.ex
@@ -1,6 +1,7 @@
 defmodule Beaker.TimeSeries.Aggregator do
   @name :beaker_time_series_aggregator
   @default_interval 60
+  @env Mix.env
 
   @moduledoc """
   `Beaker.TimeSeries.Aggregator` is the aggregation framework for time series. It's purposed mostly for internal use only.
@@ -84,7 +85,7 @@ defmodule Beaker.TimeSeries.Aggregator do
 
   @doc false
   def init(:ok) do
-    unless Mix.env == :test do
+    unless @env == :test do
       :timer.send_interval(@default_interval * 1000, :schedule_aggregation)
     end
     {:ok, Beaker.Time.last_full_minute}

--- a/lib/web/helper.ex
+++ b/lib/web/helper.ex
@@ -3,11 +3,6 @@ defmodule Beaker.Web.Helper do
 
   @colors ~w(yellow orange red magenta violet blue cyan green)
 
-  def autorefresh_interval, do: autorefresh_interval(Mix.env)
-  def autorefresh_interval(:dev), do: 5000
-  def autorefresh_interval(:prod), do: 30000
-  def autorefresh_interval(:test), do: nil
-
   def random_color do
     :random.seed(:os.timestamp)
 


### PR DESCRIPTION
- Mix is not generally available in production/release environment (i.e. exrm)
- `autorefresh_interval` was not used anywhere
